### PR TITLE
Found error on Cocktail recipe results

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -44,7 +44,7 @@ let alcoholType = "";
 // GET USER INPUT FROM MEAL TYPE DROP DOWN MENU
 $(mealTypeDropDown).click(function(e) {
   mealType = e.target.id;
-  if (mealType == "snack" || mealType == "teatime") {
+  if (mealType == "snack" || mealType == "teatime" || mealType == "breakfast") {
     proteinDropdownDiv.classList.add('hide');
   } else {
     proteinDropdownDiv.classList.remove('hide');


### PR DESCRIPTION
Hey guys! I noticed that the ingredients on the cocktail cards were displaying incorrect values. There was some type of loop behavior that was causing the cocktail ingredients from card 1 to show cocktail ingredients from all 3 cards -- card two was showing ingredients from card 2 and 3 -- card 3 is showing the correct ingredients.

I know that Braxton worked on this last night with the goal of making the cocktail cards appear more uniform but it appears that this broke the data. 

I reverted that particular function back to how it was before last night. Local Storage and the save functionality is still in tact; however, the show page (for saved recipes) will not look uniform if showing both food recipes and cocktail recipes side-by-side.
 